### PR TITLE
Fixes the issue with the hard-coded relevance that is too high

### DIFF
--- a/ChatServiceWebApi/appsettings.json
+++ b/ChatServiceWebApi/appsettings.json
@@ -17,7 +17,8 @@
   "MSCosmosDBOpenAI": {
     "CognitiveSearch": {
       "IndexName": "vector-index",
-      "MaxVectorSearchResults": 10
+      "MaxVectorSearchResults": 10,
+      "MinRelevance": 0.7
     },
     "OpenAI": {
       "CompletionsDeployment": "completions",

--- a/VectorSearchAiAssistant.Service/Models/ConfigurationOptions/CognitiveSearchSettings.cs
+++ b/VectorSearchAiAssistant.Service/Models/ConfigurationOptions/CognitiveSearchSettings.cs
@@ -10,6 +10,7 @@ namespace VectorSearchAiAssistant.Service.Models.ConfigurationOptions
     {
         public required string IndexName { get; init; }
         public required int MaxVectorSearchResults { get; init; }
+        public required double MinRelevance { get; init; }
         public required string Endpoint { get; init; }
         public required string Key { get; init; }
     }

--- a/VectorSearchAiAssistant.Service/Services/SemanticKernelRAGService.cs
+++ b/VectorSearchAiAssistant.Service/Services/SemanticKernelRAGService.cs
@@ -150,7 +150,7 @@ public class SemanticKernelRAGService : IRAGService
         var memories = await memoryPlugin.RecallAsync(
             userPrompt,
             _settings.CognitiveSearch.IndexName,
-            0.8,
+            _settings.CognitiveSearch.MinRelevance,
             _settings.CognitiveSearch.MaxVectorSearchResults);
 
         // Read the resulting user prompt embedding as soon as possible


### PR DESCRIPTION
The default, hard-coded relevance of 0.8 proves to be too high for some questions to be answered correctly.
Exposed the minimum relevance as a configuration setting and set its default value to 0.7.